### PR TITLE
META-01 | Create  trick in custom List with help of the metaprogramming

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set(PROJECT_NAME allocator_self_v2)
 set(LIB_NAME alloc_mem)
 
 #prepare executable for test functionality in custom List and std::map OFF / ON)
-set(DEMO_READY OFF)
+set(DEMO_READY ON)
 
 #SIZE OF CLUSTER IN MEMORY POOL
 set(CLUSTER_SIZE 5)

--- a/demo/List/include/List.h
+++ b/demo/List/include/List.h
@@ -28,7 +28,27 @@ public:
     virtual void virtual_plug() {}
 };
 
-template< typename T, typename allocator = self_allocator<Node<T>> >
+// small metatric to change the type of allocator from alloc<T> to alloc<Node<T>>
+template<typename T>
+struct change_allocator_t{
+    using type = T;
+};
+
+template<typename T>
+struct change_allocator_t<std::allocator<T>>{
+    using type = std::allocator<Node<T>>;
+};
+
+template<typename T>
+struct change_allocator_t<self_allocator<T>>{
+using type = self_allocator<Node<T>>;
+};
+
+template< typename T,
+          typename allocator = std::allocator<T>,
+          typename allocator_t = typename change_allocator_t<allocator>::type
+        >
+
 class List : public Node<T>{
 public:
     //using Node = Node<T>;
@@ -36,7 +56,7 @@ public:
     using size_type = std::size_t;
     using difference_type = std::ptrdiff_t;
 private:
-    allocator allocator_obj;
+    allocator_t allocator_obj;
     Node<T> * top = nullptr;
     Node<T> * bottom = nullptr;
 

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -8,6 +8,7 @@
 #include <map>
 
 #include "self_allocator/self_allocator.h"
+#include "List/include/List.h"
 
 //template<typename T>
 int count_factorial(int const & count){


### PR DESCRIPTION
Created trick in the custom List with help of the metaprogramming. Trick purpose : to not change main structure of the custom List, and allocator<T> type, could be move to allocator<Node<T>.